### PR TITLE
Rollback to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:20.9-bookworm-slim as base
+FROM node:20.9-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
The build is currently erroring as `bookworm-slim` doesn't have the python package available to it