### PR TITLE
CDPS-569 :lock: update modsec rules. 

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,3 @@
----
 # Per environment values which override defaults in hmpps-digital-prison-services/values.yaml
 
 generic-service:
@@ -8,6 +7,11 @@ generic-service:
     host: dps-dev.prison.service.justice.gov.uk
     modsecurity_enabled: true
     modsecurity_github_team: "connect-dps"
+    modsecurity_snippet: |
+      SecRuleEngine On
+      SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   env:
     INGRESS_URL: https://dps-dev.prison.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,11 @@ generic-service:
     host: dps-preprod.prison.service.justice.gov.uk
     modsecurity_enabled: true
     modsecurity_github_team: "connect-dps"
+    modsecurity_snippet: |
+      SecRuleEngine On
+      SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   env:
     INGRESS_URL: https://dps-preprod.prison.service.justice.gov.uk
@@ -83,10 +88,10 @@ generic-service:
     sscl-newcastle: 62.172.79.105/32
     sscl-newport: 217.38.237.212/32
     groups:
-      - internal
-      - prisons
-      - private_prisons
-      - police
+    - internal
+    - prisons
+    - private_prisons
+    - police
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-digital-prison-services-non-prod

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,11 @@ generic-service:
     host: dps.prison.service.justice.gov.uk
     modsecurity_enabled: true
     modsecurity_github_team: "connect-dps"
+    modsecurity_snippet: |
+      SecRuleEngine On
+      SecRuleRemoveById 949110
+      SecRuleRemoveById 942440
+      SecRuleRemoveById 920300
 
   autoscaling:
     enabled: true
@@ -87,10 +92,10 @@ generic-service:
     sscl-newcastle: 62.172.79.105/32
     sscl-newport: 217.38.237.212/32
     groups:
-      - internal
-      - prisons
-      - private_prisons
-      - police
+    - internal
+    - prisons
+    - private_prisons
+    - police
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-digital-prison-services-prod


### PR DESCRIPTION
Modsec is firing 406 errors for a number of rules. We need to let the service to run in these scenarios, potentially due to false positives.
we'll investigate why this is triggering in a later ticket.