### PR TITLE
RR-537 use the PLP team version of the prisoner list page (PLP)

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -47,7 +47,7 @@ generic-service:
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work-dev.hmpps.service.justice.gov.uk
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa-stage.hmpps.dsd.io
     INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction-dev.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk
     LEGACY_PRISON_VISITS_URL: https://prison-visits-booking-staff-dev.apps.live.cloud-platform.service.justice.gov.uk
     LICENCES_URL: https://licences-dev.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_URL: https://manage-adjudications-dev.hmpps.service.justice.gov.uk


### PR DESCRIPTION
## Description

We have now switched over to using the PLP version of the Prisoner List page (from the CIAG version). This change updates the URL for the DPS Homepage Learning and work progress service tile for the `dev` environments. Further changes will be done for other environments once tested.

The navigation bar has been changed in https://github.com/ministryofjustice/hmpps-micro-frontend-components/pull/145

https://dsdmoj.atlassian.net/browse/RR-537 