### PR TITLE
RR-537 use the PLP team version of the prisoner list page (PLP)

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -47,7 +47,7 @@ generic-service:
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work-preprod.hmpps.service.justice.gov.uk
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa-preprod.service.hmpps.dsd.io
     INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction-preprod.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
     LEGACY_PRISON_VISITS_URL: https://prison-visits-booking-staff-staging.apps.live.cloud-platform.service.justice.gov.uk
     LICENCES_URL: https://licences-preprod.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_URL: https://manage-adjudications-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -50,7 +50,7 @@ generic-service:
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work.hmpps.service.justice.gov.uk
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa.service.hmpps.dsd.io
     INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress.hmpps.service.justice.gov.uk
     LEGACY_PRISON_VISITS_URL: https://staff.prisonvisits.service.justice.gov.uk
     LICENCES_URL: https://licences.prison.service.justice.gov.uk
     MANAGE_ADJUDICATIONS_URL: https://manage-adjudications.hmpps.service.justice.gov.uk


### PR DESCRIPTION
## Description

We have now switched over to using the PLP version of the Prisoner List page (from the CIAG version). This change updates the URL for the DPS Homepage Learning and work progress service tile for the `preprod` and `prod` environments.

https://dsdmoj.atlassian.net/browse/RR-537 

Tested on `dev` here: https://github.com/ministryofjustice/hmpps-digital-prison-services/pull/91