### PR TITLE
SDIT-1384 StaffResource - catch access error

### DIFF
--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -67,4 +67,25 @@ context('SignIn', () => {
 
     indexPage.headerUserName().contains('B. Brown')
   })
+
+  it('Page shown ok when roles are not found', () => {
+    cy.setupUserAuth({ roles: [`ROLE_PRISON`] })
+    cy.task('stubGetStaffRoles', 403)
+    cy.signIn()
+    Page.verifyOnPage(IndexPage)
+  })
+
+  it('Page shown ok when roles call is unauthorised', () => {
+    cy.setupUserAuth({ roles: [`ROLE_PRISON`] })
+    cy.task('stubGetStaffRoles', 404)
+    cy.signIn()
+    Page.verifyOnPage(IndexPage)
+  })
+
+  it('Error page shown when roles call returns an unexpected error', () => {
+    cy.setupUserAuth({ roles: [`ROLE_PRISON`] })
+    cy.task('stubGetStaffRoles', 500)
+    cy.signIn({ failOnStatusCode: false, redirectPath: '/' })
+    cy.contains('Internal Server Error')
+  })
 })

--- a/integration_tests/mockApis/prison.ts
+++ b/integration_tests/mockApis/prison.ts
@@ -87,14 +87,14 @@ export default {
     })
   },
 
-  stubGetStaffRoles: () => {
+  stubGetStaffRoles: (status = 200) => {
     return stubFor({
       request: {
         method: 'GET',
         urlPattern: `/prison/api/staff/231232/LEI/roles`,
       },
       response: {
-        status: 200,
+        status,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },

--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -33,6 +33,14 @@ export default class PrisonApiRestClient implements PrisonApiClient {
   }
 
   async getStaffRoles(staffId: number, agencyId: string): Promise<StaffRole[]> {
-    return this.get<StaffRole[]>({ path: `/api/staff/${staffId}/${agencyId}/roles` })
+    try {
+      return await this.get<StaffRole[]>({ path: `/api/staff/${staffId}/${agencyId}/roles` })
+    } catch (error) {
+      if (error.status === 403 || error.status === 404) {
+        // can happen for CADM (central admin) users
+        return []
+      }
+      throw error
+    }
   }
 }


### PR DESCRIPTION
This change allows for errors from the prison-api endpoint which checks what roles the current user has. This endpoint now enforces tighter restrictions so it may now reject calls from CADMs (who may not have a relevant caseload)