### PR TITLE
Add Kilco UAT to dev allow list

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -55,6 +55,7 @@ generic-service:
       - prisons
       - accessibility-testing-1
       - circleci
+      - kilco_uat
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-digital-prison-services-non-prod


### PR DESCRIPTION
My team is working with a private prison operator's software provider by providing them API access to DPS services. They want to have access to dev DPS to complete the acceptance testing for a feature. 
We have tried to provide them access to dev DPS for this, but they are getting 403 errors. We have a suspicion that this is an issue with the IP allowlisting.
To fix this, we have added a new group (`kilco_uat`) to the allowlists repo, and we would like to add kilco_uat as a group to dev here.