### PR TITLE
CDPS-1620: Bring linting closer in line with HMPPS template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2023 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2025 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,31 +1,5 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
-import typescriptEslint from '@typescript-eslint/eslint-plugin'
 
-const defaultConfig = hmppsConfig({
-  extraIgnorePaths: ['assets/js/**/*.js'],
+export default hmppsConfig({
+  extraIgnorePaths: ['assets/'],
 })
-defaultConfig.push({
-  rules: {
-    'import/prefer-default-export': 'off',
-  },
-})
-defaultConfig.push({
-  plugins: {
-    '@typescript-eslint': typescriptEslint,
-  },
-
-  rules: {
-    'import/prefer-default-export': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      1,
-      {
-        argsIgnorePattern: 'res|next|^err|_',
-        ignoreRestSiblings: true,
-        caughtErrorsIgnorePattern: '^_',
-      },
-    ],
-  },
-})
-
-export default defaultConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
       },
       "devDependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
-        "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+        "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
         "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
         "@tsconfig/node22": "^22.0.2",
         "@types/bunyan": "^1.8.11",
@@ -65,7 +65,6 @@
         "@types/passport-oauth2": "^1.8.0",
         "@types/superagent": "^8.1.9",
         "@types/supertest": "^6.0.3",
-        "@typescript-eslint/eslint-plugin": "^8.41.0",
         "audit-ci": "^7.1.0",
         "aws-sdk-client-mock": "^4.1.0",
         "chokidar": "^4.0.3",
@@ -78,7 +77,6 @@
         "esbuild-plugin-copy": "^2.1.1",
         "esbuild-plugin-manifest": "^1.0.5",
         "esbuild-sass-plugin": "^3.3.1",
-        "eslint-import-resolver-typescript": "^4.4.4",
         "glob": "^11.0.3",
         "jest": "^30.1.1",
         "jest-html-reporter": "^4.3.0",
@@ -879,9 +877,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1028,9 +1026,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
-      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
+      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1842,21 +1840,21 @@
       "license": "MIT"
     },
     "node_modules/@ministryofjustice/eslint-config-hmpps": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/eslint-config-hmpps/-/eslint-config-hmpps-0.0.3.tgz",
-      "integrity": "sha512-ZAdcbzHfxr8uXXJ2vvrzxItKrgLYerz8ijcHVmaB5fM7ba3nZnAMcwx6qnyQbz2AvXsyVWXRuKX+/ctz0k9HXg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/eslint-config-hmpps/-/eslint-config-hmpps-0.0.5.tgz",
+      "integrity": "sha512-+X/Mu4qB/AzSX31yPSQXtSTXQMqsF+3w0nEOMeMFDu/dx2Ql2Rds6ZX3OE1P4LTgLB+ynnDnZY/CkRsw8YAkVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.32.0",
-        "@typescript-eslint/eslint-plugin": "^8.39.0",
-        "@typescript-eslint/parser": "^8.39.0",
+        "@eslint/js": "^9.35.0",
+        "@typescript-eslint/eslint-plugin": "^8.42.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "confusing-browser-globals": "^1.0.11",
-        "eslint": "^9.32.0",
+        "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
-        "eslint-plugin-cypress": "^5.1.0",
+        "eslint-plugin-cypress": "^5.1.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-prettier": "^5.5.4",
@@ -1868,19 +1866,6 @@
       },
       "engines": {
         "node": "20 || 22"
-      }
-    },
-    "node_modules/@ministryofjustice/eslint-config-hmpps/node_modules/eslint-plugin-cypress": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.0.tgz",
-      "integrity": "sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globals": "^16.2.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9"
       }
     },
     "node_modules/@ministryofjustice/eslint-config-hmpps/node_modules/globals": {
@@ -2837,17 +2822,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.41.0.tgz",
-      "integrity": "sha512-8fz6oa6wEKZrhXWro/S3n2eRJqlRcIa6SlDh59FXJ5Wp5XRZ8B9ixpJDcjadHq47hMx0u+HW6SNa6LjJQ6NLtw==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
+      "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/type-utils": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.44.0",
+        "@typescript-eslint/type-utils": "8.44.0",
+        "@typescript-eslint/utils": "8.44.0",
+        "@typescript-eslint/visitor-keys": "8.44.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2861,22 +2846,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.41.0",
+        "@typescript-eslint/parser": "^8.44.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.41.0.tgz",
-      "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
+      "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/scope-manager": "8.44.0",
+        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/typescript-estree": "8.44.0",
+        "@typescript-eslint/visitor-keys": "8.44.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2892,14 +2877,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.41.0.tgz",
-      "integrity": "sha512-b8V9SdGBQzQdjJ/IO3eDifGpDBJfvrNTp2QD9P2BeqWTGrRibgfgIlBSw6z3b6R7dPzg752tOs4u/7yCLxksSQ==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
+      "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.41.0",
-        "@typescript-eslint/types": "^8.41.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.0",
+        "@typescript-eslint/types": "^8.44.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2914,14 +2899,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.41.0.tgz",
-      "integrity": "sha512-n6m05bXn/Cd6DZDGyrpXrELCPVaTnLdPToyhBoFkLIMznRUQUEQdSp96s/pcWSQdqOhrgR1mzJ+yItK7T+WPMQ==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
+      "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0"
+        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/visitor-keys": "8.44.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2932,9 +2917,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.41.0.tgz",
-      "integrity": "sha512-TDhxYFPUYRFxFhuU5hTIJk+auzM/wKvWgoNYOPcOf6i4ReYlOoYN8q1dV5kOTjNQNJgzWN3TUUQMtlLOcUgdUw==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
+      "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2949,15 +2934,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.41.0.tgz",
-      "integrity": "sha512-63qt1h91vg3KsjVVonFJWjgSK7pZHSQFKH6uwqxAH9bBrsyRhO6ONoKyXxyVBzG1lJnFAJcKAcxLS54N1ee1OQ==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
+      "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0",
-        "@typescript-eslint/utils": "8.41.0",
+        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/typescript-estree": "8.44.0",
+        "@typescript-eslint/utils": "8.44.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2974,9 +2959,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.41.0.tgz",
-      "integrity": "sha512-9EwxsWdVqh42afLbHP90n2VdHaWU/oWgbH2P0CfcNfdKL7CuKpwMQGjwev56vWu9cSKU7FWSu6r9zck6CVfnag==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
+      "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2988,16 +2973,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.41.0.tgz",
-      "integrity": "sha512-D43UwUYJmGhuwHfY7MtNKRZMmfd8+p/eNSfFe6tH5mbVDto+VQCayeAt35rOx3Cs6wxD16DQtIKw/YXxt5E0UQ==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
+      "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.41.0",
-        "@typescript-eslint/tsconfig-utils": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/visitor-keys": "8.41.0",
+        "@typescript-eslint/project-service": "8.44.0",
+        "@typescript-eslint/tsconfig-utils": "8.44.0",
+        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/visitor-keys": "8.44.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3017,16 +3002,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.41.0.tgz",
-      "integrity": "sha512-udbCVstxZ5jiPIXrdH+BZWnPatjlYwJuJkDA4Tbo3WyYLh8NvB+h/bKeSZHDOFKfphsZYJQqaFtLeXEqurQn1A==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
+      "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.41.0",
-        "@typescript-eslint/types": "8.41.0",
-        "@typescript-eslint/typescript-estree": "8.41.0"
+        "@typescript-eslint/scope-manager": "8.44.0",
+        "@typescript-eslint/types": "8.44.0",
+        "@typescript-eslint/typescript-estree": "8.44.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3041,13 +3026,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.41.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.41.0.tgz",
-      "integrity": "sha512-+GeGMebMCy0elMNg67LRNoVnUFPIm37iu5CmHESVx56/9Jsfdpsvbv605DQ81Pi/x11IdKUsS5nzgTYbCQU9fg==",
+      "version": "8.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
+      "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.41.0",
+        "@typescript-eslint/types": "8.44.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -5705,19 +5690,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
-      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
+      "version": "9.35.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
+      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.33.0",
+        "@eslint/js": "9.35.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -5889,6 +5874,32 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.1.tgz",
+      "integrity": "sha512-LxTmZf1LLh9EklZBVvKNEZj71X9tCJnlYDviAJGsOgEVc6jz+tBODSpm02CS/9eJOfRqGsmVyvIw7LHXQ13RaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^16.2.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9"
+      }
+    },
+    "node_modules/eslint-plugin-cypress/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "rebuild": "npm run clean && npm i && npm run build",
     "postinstall": "npx patch-package",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
-    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:lint": "lint-staged",
     "precommit:verify": "npm run typecheck && npm test"
   },
   "engines": {
@@ -116,7 +116,7 @@
   },
   "devDependencies": {
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
-    "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+    "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
     "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
     "@tsconfig/node22": "^22.0.2",
     "@types/bunyan": "^1.8.11",
@@ -134,7 +134,6 @@
     "@types/passport-oauth2": "^1.8.0",
     "@types/superagent": "^8.1.9",
     "@types/supertest": "^6.0.3",
-    "@typescript-eslint/eslint-plugin": "^8.41.0",
     "audit-ci": "^7.1.0",
     "aws-sdk-client-mock": "^4.1.0",
     "chokidar": "^4.0.3",
@@ -147,7 +146,6 @@
     "esbuild-plugin-copy": "^2.1.1",
     "esbuild-plugin-manifest": "^1.0.5",
     "esbuild-sass-plugin": "^3.3.1",
-    "eslint-import-resolver-typescript": "^4.4.4",
     "glob": "^11.0.3",
     "jest": "^30.1.1",
     "jest-html-reporter": "^4.3.0",

--- a/server/controllers/dietaryRequirementsController.ts
+++ b/server/controllers/dietaryRequirementsController.ts
@@ -1,4 +1,4 @@
-import { Request, RequestHandler, Response } from 'express'
+import { RequestHandler } from 'express'
 import { format } from 'date-fns'
 import { DietaryRequirementsQueryParams, generateListMetadata, mapToQueryString } from '../utils/generateListMetadata'
 import { formatName, userHasRoles } from '../utils/utils'
@@ -14,7 +14,7 @@ export default class DietaryRequirementsController {
   ) {}
 
   public get(): RequestHandler {
-    return async (req: Request, res: Response) => {
+    return async (req, res) => {
       const { clientToken } = req.middleware
       const prisonId = res.locals.user.activeCaseLoadId
 
@@ -90,7 +90,7 @@ export default class DietaryRequirementsController {
   }
 
   public printAll(): RequestHandler {
-    return async (req: Request, res: Response) => {
+    return async (req, res) => {
       const { clientToken } = req.middleware
       const prisonId = res.locals.user.activeCaseLoadId
 

--- a/server/controllers/homepageController.ts
+++ b/server/controllers/homepageController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { RequestHandler } from 'express'
 import { Role } from '../enums/role'
 import config from '../config'
 import { userHasRoles } from '../utils/utils'
@@ -17,7 +17,7 @@ export default class HomepageController {
   ) {}
 
   public displayHomepage(): RequestHandler {
-    return async (req: Request, res: Response, next: NextFunction) => {
+    return async (req, res) => {
       const { activeCaseLoadId } = res.locals.user
       const userHasPrisonCaseLoad =
         Boolean(activeCaseLoadId) && activeCaseLoadId !== '' && activeCaseLoadId !== 'CADM_I'
@@ -57,7 +57,7 @@ export default class HomepageController {
   }
 
   public search(): RequestHandler {
-    return async (req: Request, res: Response, next: NextFunction) => {
+    return async (req, res) => {
       const { searchType, name, location } = req.body
 
       if (searchType === undefined || searchType === 'local') {

--- a/server/controllers/managedPageController.test.ts
+++ b/server/controllers/managedPageController.test.ts
@@ -1,3 +1,4 @@
+import { Request, Response } from 'express'
 import { Role } from '../enums/role'
 import ContentfulService from '../services/contentfulService'
 import { managedPagesMock } from '../mocks/managedPagesMock'
@@ -5,8 +6,8 @@ import ManagedPageController from './managedPageController'
 
 describe('Managed Page Controller', () => {
   let contentfulService: ContentfulService
-  let req: any
-  let res: any
+  let req: Request
+  let res: Response
   let controller: ManagedPageController
 
   beforeEach(() => {
@@ -23,7 +24,7 @@ describe('Managed Page Controller', () => {
       },
       path: '/',
       flash: jest.fn(),
-    } as any
+    } as unknown as Request
 
     res = {
       locals: {
@@ -36,7 +37,7 @@ describe('Managed Page Controller', () => {
       },
       render: jest.fn(),
       redirect: jest.fn(),
-    } as any
+    } as unknown as Response
 
     contentfulService = { getManagedPage: jest.fn(async () => managedPagesMock[0]) } as unknown as ContentfulService
     controller = new ManagedPageController(contentfulService)

--- a/server/controllers/managedPageController.ts
+++ b/server/controllers/managedPageController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { RequestHandler } from 'express'
 import ContentfulService from '../services/contentfulService'
 
 /**
@@ -8,7 +8,7 @@ export default class ManagedPageController {
   constructor(private readonly contentfulService: ContentfulService) {}
 
   public displayManagedPage(slug: string): RequestHandler {
-    return async (req: Request, res: Response, next: NextFunction) => {
+    return async (_req, res) => {
       try {
         const managedPage = await this.contentfulService.getManagedPage(slug)
 
@@ -16,6 +16,7 @@ export default class ManagedPageController {
           pageTitle: managedPage.title,
           managedPage,
         })
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (_error) {
         res.render('notFound')
       }

--- a/server/controllers/whatsNewController.test.ts
+++ b/server/controllers/whatsNewController.test.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from 'express'
+import { NextFunction, Request, Response } from 'express'
 import { Role } from '../enums/role'
 import ContentfulService from '../services/contentfulService'
 import { whatsNewPostsMock } from '../mocks/whatsNewPostsMock'
@@ -10,6 +10,7 @@ describe('Whats New Controller', () => {
   let contentfulService: ContentfulService
   let req: Request
   let res: Response
+  const next: NextFunction = jest.fn()
   let controller: WhatsNewController
 
   beforeEach(() => {
@@ -56,7 +57,7 @@ describe('Whats New Controller', () => {
 
   describe('Display whats new page', () => {
     it('should get whats new list', async () => {
-      await controller.displayWhatsNewList()(req, res, null)
+      await controller.displayWhatsNewList()(req, res, next)
 
       expect(contentfulService.getWhatsNewPosts).toHaveBeenCalled()
       expect(res.render).toHaveBeenCalledWith('pages/whatsNew', {
@@ -69,7 +70,7 @@ describe('Whats New Controller', () => {
 
   describe('Display whats new post', () => {
     it('should get whats new post', async () => {
-      await controller.displayWhatsNewPost()(req, res, null)
+      await controller.displayWhatsNewPost()(req, res, next)
 
       expect(contentfulService.getWhatsNewPost).toHaveBeenCalled()
       expect(res.render).toHaveBeenCalledWith('pages/whatsNewPost', {

--- a/server/controllers/whatsNewController.ts
+++ b/server/controllers/whatsNewController.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, RequestHandler, Response } from 'express'
+import { RequestHandler } from 'express'
 import ContentfulService from '../services/contentfulService'
 
 /**
@@ -8,7 +8,7 @@ export default class WhatsNewController {
   constructor(private readonly contentfulService: ContentfulService) {}
 
   public displayWhatsNewList(): RequestHandler {
-    return async (req: Request, res: Response, next: NextFunction) => {
+    return async (req, res) => {
       const { activeCaseLoadId } = res.locals.user
       const pageSize = 10
       const currentPage = +req.query.page || 1
@@ -24,7 +24,7 @@ export default class WhatsNewController {
   }
 
   public displayWhatsNewPost(): RequestHandler {
-    return async (req: Request, res: Response, next: NextFunction) => {
+    return async (req, res) => {
       const { slug } = req.params
 
       try {
@@ -34,6 +34,7 @@ export default class WhatsNewController {
           pageTitle: whatsNewPost.title,
           whatsNewPost,
         })
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (_error) {
         res.render('notFound')
       }

--- a/server/data/interfaces/contentful.ts
+++ b/server/data/interfaces/contentful.ts
@@ -1,0 +1,21 @@
+/** Asset links within a Contentful GraphQL “Rich Text” field */
+export interface ArticleTextLinks {
+  assets?: ArticleTextAssets
+}
+
+interface ArticleTextAssets {
+  block?: Asset[]
+  hyperlink?: Asset[]
+}
+
+interface Asset {
+  __typename: 'Asset'
+  sys: { id: string }
+  contentType: string
+  url: string
+  title: string
+  description: string
+  fileName?: string
+  width?: number
+  height?: number
+}

--- a/server/data/interfaces/managedPage.ts
+++ b/server/data/interfaces/managedPage.ts
@@ -1,4 +1,5 @@
 import { Document } from '@contentful/rich-text-types'
+import { ArticleTextLinks } from './contentful'
 
 export interface ManagedPage {
   title: string
@@ -11,7 +12,7 @@ export interface ManagedPageApollo {
   slug: string
   content?: {
     json: Document
-    links?: any
+    links?: ArticleTextLinks
   }
 }
 

--- a/server/data/interfaces/whatsNewPost.ts
+++ b/server/data/interfaces/whatsNewPost.ts
@@ -1,4 +1,5 @@
 import { Document } from '@contentful/rich-text-types'
+import { ArticleTextLinks } from './contentful'
 
 export interface WhatsNewPost {
   title: string
@@ -13,7 +14,7 @@ export interface WhatsNewPostApollo {
   slug: string
   body?: {
     json: Document
-    links?: any
+    links?: ArticleTextLinks
   }
   summary: string
   date: string

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -2,7 +2,7 @@ import { ApiConfig, RestClient as HmppsRestClient } from '@ministryofjustice/hmp
 import appConfig from '../config'
 import logger, { warnLevelLogger } from '../../logger'
 
-export default class RestClient extends HmppsRestClient {
+export default abstract class RestClient extends HmppsRestClient {
   constructor(
     protected readonly name: string,
     protected readonly config: ApiConfig,

--- a/server/enums/role.ts
+++ b/server/enums/role.ts
@@ -3,3 +3,5 @@ export enum Role {
   PrisonUser = 'PRISON',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
 }
+
+export default { Role }

--- a/server/middleware/ensureActiveCaseLoadSet.ts
+++ b/server/middleware/ensureActiveCaseLoadSet.ts
@@ -5,7 +5,7 @@ import { CaseLoad } from '../data/interfaces/caseLoad'
 import { PrisonUser } from '../interfaces/prisonUser'
 
 export function ensureActiveCaseLoadSet(userService: UserService): RequestHandler {
-  return async (req, res, next) => {
+  return async (_req, res, next) => {
     try {
       if (res.locals.user && res.locals.user.activeCaseLoad && res.locals.user.activeCaseLoadId) return next()
 
@@ -41,3 +41,5 @@ async function getActiveCaseload(
 
   return null
 }
+
+export default { ensureActiveCaseLoadSet }

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -1,6 +1,10 @@
 import express, { Router } from 'express'
 
-import { endpointHealthComponent, monitoringMiddleware } from '@ministryofjustice/hmpps-monitoring'
+import {
+  endpointHealthComponent,
+  EndpointHealthComponentOptions,
+  monitoringMiddleware,
+} from '@ministryofjustice/hmpps-monitoring'
 import type { ApplicationInfo } from '../applicationInfo'
 import config from '../config'
 import logger from '../../logger'
@@ -15,8 +19,8 @@ export default function setUpHealthChecks(applicationInfo: ApplicationInfo): Rou
   const middleware = monitoringMiddleware({
     applicationInfo,
     healthComponents: apiConfig
-      .filter(([_, options]: [string, any]) => options?.healthPath)
-      .map(([name, options]: [string, any & { healthPath: string }]) => endpointHealthComponent(logger, name, options)),
+      .filter(([_, options]) => 'healthPath' in options && options.healthPath)
+      .map(([name, options]) => endpointHealthComponent(logger, name, options as EndpointHealthComponentOptions)),
   })
 
   router.get('/health', middleware.health)

--- a/server/mocks/paginationMock.ts
+++ b/server/mocks/paginationMock.ts
@@ -12,3 +12,5 @@ export const paginationMock: Pagination = {
   totalElements: 1,
   totalPages: 1,
 }
+
+export default { paginationMock }

--- a/server/mocks/prisonRollCountSummaryMock.ts
+++ b/server/mocks/prisonRollCountSummaryMock.ts
@@ -7,3 +7,5 @@ export const prisonEstablishmentRollSummaryMock: EstablishmentRollSummary = {
   numOutToday: 40,
   numCurrentPopulation: 50,
 }
+
+export default { prisonEstablishmentRollSummaryMock }

--- a/server/mocks/whatsNewDataMock.ts
+++ b/server/mocks/whatsNewDataMock.ts
@@ -6,3 +6,5 @@ export const whatsNewDataMock: WhatsNewData = {
   whatsNewPosts: whatsNewPostsMock,
   pagination: paginationMock,
 }
+
+export default { whatsNewDataMock }

--- a/server/services/contentfulService.ts
+++ b/server/services/contentfulService.ts
@@ -1,6 +1,7 @@
 import { documentToHtmlString } from '@contentful/rich-text-html-renderer'
 import { ApolloClient, gql, TypedDocumentNode } from '@apollo/client'
-import { BLOCKS, INLINES } from '@contentful/rich-text-types'
+import { AssetHyperlink, AssetLinkBlock, BLOCKS, INLINES } from '@contentful/rich-text-types'
+import { ArticleTextLinks } from '../data/interfaces/contentful'
 import { WhatsNewData } from '../data/interfaces/whatsNewData'
 import {
   WhatsNewPost,
@@ -252,15 +253,13 @@ export default class ContentfulService {
     }))[0]
   }
 
-  private renderOptions(links: any) {
-    const hyperlinkMap: Map<any, any> = new Map(
-      links?.assets?.hyperlink?.map((hyperlink: any) => [hyperlink.sys.id, hyperlink]),
-    )
-    const blockMap: Map<any, any> = new Map(links?.assets?.block?.map((block: any) => [block.sys.id, block]))
+  private renderOptions(links: ArticleTextLinks) {
+    const hyperlinkMap = new Map(links?.assets?.hyperlink?.map(hyperlink => [hyperlink.sys.id, hyperlink]))
+    const blockMap = new Map(links?.assets?.block?.map(block => [block.sys.id, block]))
 
     return {
       renderNode: {
-        [BLOCKS.EMBEDDED_ASSET]: (node: any) => {
+        [BLOCKS.EMBEDDED_ASSET]: (node: AssetLinkBlock) => {
           // find the asset in the assetMap by ID
           const asset = blockMap?.get(node.data.target.sys.id)
 
@@ -278,7 +277,7 @@ export default class ContentfulService {
 
           return ''
         },
-        [INLINES.ASSET_HYPERLINK]: (node: any) => {
+        [INLINES.ASSET_HYPERLINK]: (node: AssetHyperlink) => {
           // find the asset in the assetMap by ID
           const asset = hyperlinkMap?.get(node.data.target.sys.id)
 

--- a/server/test/mocks/userDetailsMock.ts
+++ b/server/test/mocks/userDetailsMock.ts
@@ -24,3 +24,5 @@ export const userDetailsMock: UserDetail[] = [
     active: true,
   },
 ]
+
+export default { userDetailsMock }

--- a/server/utils/azureAppInsights.ts
+++ b/server/utils/azureAppInsights.ts
@@ -6,15 +6,17 @@ import {
   setup,
   TelemetryClient,
 } from 'applicationinsights'
+import { CorrelationContext } from 'applicationinsights/out/AutoCollection/CorrelationContextManager'
 import { EnvelopeTelemetry } from 'applicationinsights/out/Declarations/Contracts'
-import { RequestHandler } from 'express'
+import { Request, RequestHandler } from 'express'
 import type { ApplicationInfo } from '../applicationInfo'
 
 const requestPrefixesToIgnore = ['GET /assets/', 'GET /health', 'GET /ping', 'GET /info']
 const dependencyPrefixesToIgnore = ['sqs']
 
 export type ContextObject = {
-  [name: string]: any
+  ['http.ServerRequest']?: Request
+  correlationContext?: CorrelationContext
 }
 
 export function initialiseAppInsights(): void {

--- a/server/utils/dateHelpers.test.ts
+++ b/server/utils/dateHelpers.test.ts
@@ -61,8 +61,7 @@ describe('parseDate', () => {
     'For input %s return Invalid Date (NaN)',
     (date: string) => {
       const val = parseDate(date)
-      // eslint-disable-next-line no-restricted-globals
-      expect(isNaN(val.getTime())).toBeTruthy()
+      expect(Number.isNaN(val.getTime())).toBeTruthy()
     },
   )
 })

--- a/server/utils/pluralise.ts
+++ b/server/utils/pluralise.ts
@@ -44,3 +44,5 @@ export const pluralise = (
   const pluralised = [1, -1].includes(count) ? word : options?.plural || notStandardPlurals[word] || `${word}s`
   return includeCount ? `${count} ${pluralised}` : pluralised
 }
+
+export default { pluralise }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -145,6 +145,7 @@ export const assetMap = (url: string) => {
   try {
     const assetMetadataPath = path.resolve(__dirname, '../../assets/manifest.json')
     assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (_e) {
     logger.error('Could not read asset manifest file')
   }


### PR DESCRIPTION
- removed eslint overrides to the shared HMPPS config – this is the cause of all subsequent changes to appease `eslint` and `tsc`
- the `any` type is to be avoided so more type annotations and assertions are needed in a bunch of places; particularly tests
- normalised `default` exports to stop eslint complaining, but imports are still all the same
- these changes lead to no meaningful difference in the transpiled javascript; i’ve avoided logic changes even in terms of error handling
    - swapping `isNaN` (which behaves weirdly) for `Number.isNaN` in tests, but there’s no logical difference in our case