### PR TITLE
CDPS-1394: Express 5 compatibility

### DIFF
--- a/server/controllers/homepageController.ts
+++ b/server/controllers/homepageController.ts
@@ -58,7 +58,7 @@ export default class HomepageController {
 
   public search(): RequestHandler {
     return async (req, res) => {
-      const { searchType, name, location } = req.body
+      const { searchType, name, location } = req.body ?? {}
 
       if (searchType === undefined || searchType === 'local') {
         return res.redirect(

--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -2,10 +2,9 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
@@ -19,5 +18,5 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/server/routes/dietaryRequirementsRouter.ts
+++ b/server/routes/dietaryRequirementsRouter.ts
@@ -1,15 +1,9 @@
-import { RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import { Services } from '../services'
 import DietaryRequirementsController from '../controllers/dietaryRequirementsController'
 
 export default function dietaryRequirementsRouter(services: Services): Router {
   const router = Router()
-
-  const get = (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.get(
-      path,
-      handlers.map(handler => handler),
-    )
 
   const dietaryRequirementsController = new DietaryRequirementsController(
     services.dietReportingService,
@@ -17,8 +11,8 @@ export default function dietaryRequirementsRouter(services: Services): Router {
     services.auditService,
   )
 
-  get('/', dietaryRequirementsController.get())
-  get('/print-all', dietaryRequirementsController.printAll())
+  router.get('/', dietaryRequirementsController.get())
+  router.get('/print-all', dietaryRequirementsController.printAll())
 
   return router
 }

--- a/server/routes/dietaryRequirementsRouter.ts
+++ b/server/routes/dietaryRequirementsRouter.ts
@@ -1,6 +1,5 @@
 import { RequestHandler, Router } from 'express'
 import { Services } from '../services'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import DietaryRequirementsController from '../controllers/dietaryRequirementsController'
 
 export default function dietaryRequirementsRouter(services: Services): Router {
@@ -9,7 +8,7 @@ export default function dietaryRequirementsRouter(services: Services): Router {
   const get = (path: string | string[], ...handlers: RequestHandler[]) =>
     router.get(
       path,
-      handlers.map(handler => asyncMiddleware(handler)),
+      handlers.map(handler => handler),
     )
 
   const dietaryRequirementsController = new DietaryRequirementsController(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,5 +1,4 @@
 import { type RequestHandler, Router } from 'express'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 import HomepageController from '../controllers/homepageController'
 import whatsNewRouter from './whatsNewRouter'
@@ -12,12 +11,12 @@ export default function routes(services: Services): Router {
   const get = (path: string | string[], ...handlers: RequestHandler[]) =>
     router.get(
       path,
-      handlers.map(handler => asyncMiddleware(handler)),
+      handlers.map(handler => handler),
     )
   const post = (path: string | string[], ...handlers: RequestHandler[]) =>
     router.post(
       path,
-      handlers.map(handler => asyncMiddleware(handler)),
+      handlers.map(handler => handler),
     )
 
   const homepageController = new HomepageController(
@@ -31,12 +30,9 @@ export default function routes(services: Services): Router {
   router.use(managedPageRouter(services))
   router.use('/whats-new', whatsNewRouter(services))
   router.use('/dietary-requirements', dietaryRequirementsRouter(services))
-  router.get(
-    '/establishment-roll{*path}',
-    asyncMiddleware(async (req, res) => {
-      res.render('pages/establishmentRollHasMoved', { establishmentRollUrl: config.apis.establishmentRoll.ui_url })
-    }),
-  )
+  router.get('/establishment-roll{*path}', (_req, res) => {
+    res.render('pages/establishmentRollHasMoved', { establishmentRollUrl: config.apis.establishmentRoll.ui_url })
+  })
 
   return router
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,4 +1,4 @@
-import { type RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import type { Services } from '../services'
 import HomepageController from '../controllers/homepageController'
 import whatsNewRouter from './whatsNewRouter'
@@ -8,16 +8,6 @@ import config from '../config'
 
 export default function routes(services: Services): Router {
   const router = Router()
-  const get = (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.get(
-      path,
-      handlers.map(handler => handler),
-    )
-  const post = (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.post(
-      path,
-      handlers.map(handler => handler),
-    )
 
   const homepageController = new HomepageController(
     services.contentfulService,
@@ -25,8 +15,8 @@ export default function routes(services: Services): Router {
     services.serviceData,
   )
 
-  get('/', homepageController.displayHomepage())
-  post('/search', homepageController.search())
+  router.get('/', homepageController.displayHomepage())
+  router.post('/search', homepageController.search())
   router.use(managedPageRouter(services))
   router.use('/whats-new', whatsNewRouter(services))
   router.use('/dietary-requirements', dietaryRequirementsRouter(services))

--- a/server/routes/managedPageRouter.ts
+++ b/server/routes/managedPageRouter.ts
@@ -1,6 +1,5 @@
 import { RequestHandler, Router } from 'express'
 import { Services } from '../services'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import ManagedPageController from '../controllers/managedPageController'
 
 export default function whatsNewRouter(services: Services): Router {
@@ -9,7 +8,7 @@ export default function whatsNewRouter(services: Services): Router {
   const get = (path: string | string[], ...handlers: RequestHandler[]) =>
     router.get(
       path,
-      handlers.map(handler => asyncMiddleware(handler)),
+      handlers.map(handler => handler),
     )
 
   const managedPageController = new ManagedPageController(services.contentfulService)

--- a/server/routes/managedPageRouter.ts
+++ b/server/routes/managedPageRouter.ts
@@ -1,22 +1,16 @@
-import { RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import { Services } from '../services'
 import ManagedPageController from '../controllers/managedPageController'
 
 export default function whatsNewRouter(services: Services): Router {
   const router = Router()
 
-  const get = (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.get(
-      path,
-      handlers.map(handler => handler),
-    )
-
   const managedPageController = new ManagedPageController(services.contentfulService)
 
-  get('/accessibility-statement', managedPageController.displayManagedPage('accessibility-statement'))
-  get('/privacy-policy', managedPageController.displayManagedPage('privacy-policy'))
-  get('/terms-and-conditions', managedPageController.displayManagedPage('terms-and-conditions'))
-  get('/cookies-policy', managedPageController.displayManagedPage('cookies-policy'))
+  router.get('/accessibility-statement', managedPageController.displayManagedPage('accessibility-statement'))
+  router.get('/privacy-policy', managedPageController.displayManagedPage('privacy-policy'))
+  router.get('/terms-and-conditions', managedPageController.displayManagedPage('terms-and-conditions'))
+  router.get('/cookies-policy', managedPageController.displayManagedPage('cookies-policy'))
 
   router.use('/learn-more-about-dps', managedPageController.displayManagedPage('learn-more-about-dps'))
 

--- a/server/routes/whatsNewRouter.ts
+++ b/server/routes/whatsNewRouter.ts
@@ -1,20 +1,14 @@
-import { RequestHandler, Router } from 'express'
+import { Router } from 'express'
 import { Services } from '../services'
 import WhatsNewController from '../controllers/whatsNewController'
 
 export default function whatsNewRouter(services: Services): Router {
   const router = Router()
 
-  const get = (path: string | string[], ...handlers: RequestHandler[]) =>
-    router.get(
-      path,
-      handlers.map(handler => handler),
-    )
-
   const whatsNewController = new WhatsNewController(services.contentfulService)
 
-  get('/', whatsNewController.displayWhatsNewList())
-  get('/:slug', whatsNewController.displayWhatsNewPost())
+  router.get('/', whatsNewController.displayWhatsNewList())
+  router.get('/:slug', whatsNewController.displayWhatsNewPost())
 
   return router
 }

--- a/server/routes/whatsNewRouter.ts
+++ b/server/routes/whatsNewRouter.ts
@@ -1,6 +1,5 @@
 import { RequestHandler, Router } from 'express'
 import { Services } from '../services'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import WhatsNewController from '../controllers/whatsNewController'
 
 export default function whatsNewRouter(services: Services): Router {
@@ -9,7 +8,7 @@ export default function whatsNewRouter(services: Services): Router {
   const get = (path: string | string[], ...handlers: RequestHandler[]) =>
     router.get(
       path,
-      handlers.map(handler => asyncMiddleware(handler)),
+      handlers.map(handler => handler),
     )
 
   const whatsNewController = new WhatsNewController(services.contentfulService)


### PR DESCRIPTION
`asyncMiddleware` is not needed since express 5 can already deal with thrown exceptions inside request handlers. cf. [template project](https://github.com/ministryofjustice/hmpps-template-typescript/pull/560) removed it during the upgrade