### PR TITLE
CDPS-1920: Add dash to fix location search filter.

### DIFF
--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -108,7 +108,7 @@ describe('prisonerSearchService', () => {
       expect(prisonerSearchApi.locationSearch).toHaveBeenCalledWith(
         'LEI',
         expect.objectContaining({
-          location: 'LEI-2',
+          location: 'LEI-2-',
         }),
       )
     })

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -12,7 +12,7 @@ export default class PrisonerSearchService {
 
     const prisonerSearchClient = this.prisonerSearchApiClientBuilder(clientToken)
     return prisonerSearchClient.locationSearch(activeCaseLoadId, {
-      location: location === activeCaseLoadId ? '' : location,
+      location: location === activeCaseLoadId ? '' : `${location}-`, // Dash added to ensure correct results.
       size,
       page,
       term,


### PR DESCRIPTION
Currently location filtering in the Prisoner Search isn’t working as expected - because of the way Prisoner Search API works matching location codes beginning with  FNI-C also matches locations beginning  FNI-CSC, so you get more results back than you should.

This appends a dash, the agreed solution.