### PR TITLE
CDPS-1925: Ensure a caseload is actually set

### DIFF
--- a/server/middleware/ensureActiveCaseLoadSet.ts
+++ b/server/middleware/ensureActiveCaseLoadSet.ts
@@ -12,7 +12,7 @@ export function ensureActiveCaseLoadSet(userService: UserService): RequestHandle
       if (res.locals.user && res.locals.user.caseLoads) {
         const activeCaseLoad = await getActiveCaseload(res.locals.user.caseLoads, userService, res.locals.user)
         res.locals.user.activeCaseLoad = activeCaseLoad
-        res.locals.user.activeCaseLoadId = activeCaseLoad?.caseLoadId
+        res.locals.user.activeCaseLoadId = activeCaseLoad.caseLoadId
       }
       return next()
     } catch (error) {
@@ -22,11 +22,7 @@ export function ensureActiveCaseLoadSet(userService: UserService): RequestHandle
   }
 }
 
-async function getActiveCaseload(
-  caseloads: CaseLoad[],
-  userService: UserService,
-  user: PrisonUser,
-): Promise<CaseLoad | null> {
+async function getActiveCaseload(caseloads: CaseLoad[], userService: UserService, user: PrisonUser): Promise<CaseLoad> {
   const activeCaseload = caseloads.find(caseload => caseload.currentlyActive)
   if (activeCaseload) {
     return activeCaseload
@@ -39,7 +35,9 @@ async function getActiveCaseload(
     return potentialCaseLoad
   }
 
-  return null
+  throw new Error(
+    `No potential caseloads for user: ${user.username} (hmpps-micro-frontend-components likely set DEFAULT_USER_ACCESS)`,
+  )
 }
 
 export default { ensureActiveCaseLoadSet }


### PR DESCRIPTION
This should stop us calling locations API with an undefined caseload.

From what I see here: 

[https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/DataModel~/{"eventId"%3A"3eb89902-3d87-11f1-9d1d-000d3a86bc14"%2C"timestamp"%3A"2026-04-21T13%3A37%3A27.711Z"}/ComponentId~/{"Name"%3A"nomisapi-prod"%2C"ResourceGroup"%3A"nomisapi-prod-rg"%2C"SubscriptionId"%3A"a5ddf257-3b21-4ba9-a28c-ab30f751b383"}](https://portal.azure.com/#view/AppInsightsExtension/DetailsV2Blade/DataModel~/%7B%22eventId%22%3A%223eb89902-3d87-11f1-9d1d-000d3a86bc14%22%2C%22timestamp%22%3A%222026-04-21T13%3A37%3A27.711Z%22%7D/ComponentId~/%7B%22Name%22%3A%22nomisapi-prod%22%2C%22ResourceGroup%22%3A%22nomisapi-prod-rg%22%2C%22SubscriptionId%22%3A%22a5ddf257-3b21-4ba9-a28c-ab30f751b383%22%7D)

The error arises like so:

1. User acesses homepage with no active caseload.

2. MFE calls manage users api to get caseloads.

3. MFE should, in principle, set an active caseload by calling prison API, but it doesn’t when the user has no caseloads. It is short circuited by:

`if (!potentialCaseLoad) return DEFAULT_USER_ACCESS`

So caseloads is set to [], an empty array, and activecaseload is set to null.

4. Homepage tries to ensure an active caseload is set, and falls into this if:

```
if (res.locals.user && res.locals.user.caseLoads) {
     const activeCaseLoad = await getActiveCaseload(res.locals.user.caseLoads, userService, res.locals.user)
     res.locals.user.activeCaseLoad = activeCaseLoad
     res.locals.user.activeCaseLoadId = activeCaseLoad?.caseLoadId
   }
```

5. Homepage tries to get active caseload with a function like:

```
async function getActiveCaseload(
  caseloads: CaseLoad[],
  ...
): Promise<CaseLoad | null> {
  const activeCaseload = caseloads.find(caseload => caseload.currentlyActive) // Wont be one
  if (activeCaseload) {
    ...
  }
  const potentialCaseLoad = caseloads.find(cl => cl.caseLoadId !== '___') // Wont be any
  if (potentialCaseLoad) {
    ...
  }
  return null // this is returned.
}
```
So res.locals.user.activeCaseLoadId = activeCaseLoad?.caseLoadId will be undefined because activeCaseLoad is null.

6. Homepage calls locations API with undefined.