### PR TITLE
CDPS-1941-bugfix fixed recent arrival filter logic

### DIFF
--- a/server/controllers/dietaryRequirementsController.test.ts
+++ b/server/controllers/dietaryRequirementsController.test.ts
@@ -191,7 +191,7 @@ describe('DietaryRequirementsController', () => {
         description: 'location only',
         query: { topLocationLevel: ['B', 'C'], recentArrival: 'true' },
         expectedDietaryConstraints: undefined,
-        expectedLocationConstraints: { topLocationLevel: ['B', 'C'], recentArrival: ['ARRIVED_LAST_3_DAYS'] },
+        expectedLocationConstraints: { topLocationLevel: ['B', 'C'], recentArrival: ['true'] },
       },
       {
         description: 'both dietary and location',
@@ -207,7 +207,7 @@ describe('DietaryRequirementsController', () => {
           medicalDietaryRequirements: ['COELIAC'],
           foodAllergies: ['PEANUTS'],
         },
-        expectedLocationConstraints: { topLocationLevel: ['B'], recentArrival: ['ARRIVED_LAST_3_DAYS'] },
+        expectedLocationConstraints: { topLocationLevel: ['B'], recentArrival: ['true'] },
       },
     ])(
       'Fetches faceted filters correctly for $description',
@@ -386,13 +386,13 @@ describe('DietaryRequirementsController', () => {
         description: 'location + recent arrival',
         query: { topLocationLevel: 'B', recentArrival: 'true' },
         expectedDietaryConstraints: undefined,
-        expectedLocationConstraints: { topLocationLevel: ['B'], recentArrival: ['ARRIVED_LAST_3_DAYS'] },
+        expectedLocationConstraints: { topLocationLevel: ['B'], recentArrival: ['true'] },
       },
       {
         description: 'all filter types combined',
         query: {
           topLocationLevel: ['A', 'B'],
-          recentArrival: 'true',
+          recentArrival: ['true'],
           personalisedDietaryRequirements: ['VEGAN'],
           medicalDietaryRequirements: ['COELIAC'],
           foodAllergies: ['PEANUTS'],
@@ -404,7 +404,7 @@ describe('DietaryRequirementsController', () => {
         },
         expectedLocationConstraints: {
           topLocationLevel: ['A', 'B'],
-          recentArrival: ['ARRIVED_LAST_3_DAYS'],
+          recentArrival: ['true'],
         },
       },
     ])(

--- a/server/controllers/dietaryRequirementsController.ts
+++ b/server/controllers/dietaryRequirementsController.ts
@@ -410,7 +410,7 @@ export default class DietaryRequirementsController {
       if (queryParams.foodAllergies) constraints.foodAllergies = queryParams.foodAllergies
     } else if (group === 'location' && config.features.locationAndRecentArrivalFilters) {
       if (queryParams.topLocationLevel) constraints.topLocationLevel = queryParams.topLocationLevel
-      if (queryParams.recentArrival) constraints.recentArrival = ['ARRIVED_LAST_3_DAYS']
+      if (queryParams.recentArrival) constraints.recentArrival = ['true']
     }
     return constraints
   }
@@ -424,7 +424,7 @@ export default class DietaryRequirementsController {
       }
     }
     if (fields.includes('topLocationLevel') && req.query.recentArrival) {
-      constraints.recentArrival = ['ARRIVED_LAST_3_DAYS']
+      constraints.recentArrival = ['true']
     }
     return constraints
   }


### PR DESCRIPTION
Fixed a bug which erroneously checked a boolean value for `recentArrivals` but was given the raw value `ARRIVED_LAST_3_DAYS` instead -> now checks if the value is `true` before filtering